### PR TITLE
[FEATURE] Allow SQL functions in mapping.referenceField configuration

### DIFF
--- a/Classes/Utility/MappingUtility.php
+++ b/Classes/Utility/MappingUtility.php
@@ -223,7 +223,7 @@ class MappingUtility
                                     DeletedRestriction::class
                             )
                     );
-            $res = $queryBuilder->select($referenceField, $valueField)
+            $res = $queryBuilder->selectLiteral($referenceField, $valueField)
                     ->from($mappingData['table'])
                     ->where($whereClause)
                     ->execute();


### PR DESCRIPTION
This change allows to use SQL functions like (CONCAT, SUM, etc.) 
in `mapping.referenceField` configuration.

Especially this is useful to map the records without any identity field. 
Since TYPO3 schema mechanisms do not allow VIRTUAL columns, 
and external_import does not provide other ways to map the MM relations 
against multiple columns and fields, this feature is mandatory. 

It can be used as follows:

```
'mapping' => [
    'table' => 'tx_some_ext_domain_model_contact', // some table without full_name
    'referenceField' => 'CONCAT(first_name, \' \', last_name)'
]
```