### PR TITLE
Exclude various resources from package

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+.gitattributes export-ignore
+.travis.yml export-ignore
+Tests/ export-ignore


### PR DESCRIPTION
Neither tests nor build-related resources should be bundled in distribution packages.