### PR TITLE
[BUGFIX] Wrong crdate creation

### DIFF
--- a/Classes/Utility/ReportingUtility.php
+++ b/Classes/Utility/ReportingUtility.php
@@ -119,6 +119,8 @@ class ReportingUtility implements LoggerAwareInterface
             $messages = $this->importer->getMessages();
             $importContext = $this->importer->getContext();
             $now = new \DateTime();
+            $now->setTimestamp($this->context->getPropertyFromAspect('date', 'timestamp'));
+
             try {
                 $currentUser = $this->context->getPropertyFromAspect('backend.user', 'id');
             } catch (AspectNotFoundException $e) {

--- a/Classes/Utility/ReportingUtility.php
+++ b/Classes/Utility/ReportingUtility.php
@@ -118,13 +118,7 @@ class ReportingUtility implements LoggerAwareInterface
         if (!$this->importer->isPreview()) {
             $messages = $this->importer->getMessages();
             $importContext = $this->importer->getContext();
-            try {
-                $now = new \DateTime(
-                        $this->context->getPropertyFromAspect('date', 'timestamp')
-                );
-            } catch (\Exception $e) {
-                $now = new \DateTime();
-            }
+            $now = new \DateTime();
             try {
                 $currentUser = $this->context->getPropertyFromAspect('backend.user', 'id');
             } catch (AspectNotFoundException $e) {


### PR DESCRIPTION
A date from a specific timestamp may be created with \Date('@timestamp'). 

This also leaves away context api usage, because the creation logic remains the same.

Closes: #134