### PR TITLE
[BUGFIX] Prevent SQL error on first run

### DIFF
--- a/Classes/Step/StoreDataStep.php
+++ b/Classes/Step/StoreDataStep.php
@@ -311,7 +311,7 @@ class StoreDataStep extends AbstractStep
                 );
                 $inserts = count($tce->substNEWwithIDs);
                 // Update the slug fields, if activated
-                if ($updateSlugs) {
+                if ($updateSlugs && count($updatedUids) > 0) {
                     $this->updateSlugs($table, $updatedUids);
                 }
 


### PR DESCRIPTION
SlugUtility::updateAll() generates a where uid in () query with empty uid list