### PR TITLE
Use correct github repository for docs editing

### DIFF
--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -8,7 +8,7 @@ about_new_build = typo3@ideative.ch
 
 [html_theme_options]
 github_branch = master
-github_repository = cobwebch
+github_repository = cobwebch/external_import
 project_contact =
 project_discussions =
 project_home = https://github.com/cobwebch/external_import


### PR DESCRIPTION
This makes sure the "Edit" link on docs.typo3.org actually points at this repository.