### PR TITLE
[TASK] Use GeneralUtility::getFileAbsFileName for resolving web assets

### DIFF
--- a/Classes/Controller/DataModuleController.php
+++ b/Classes/Controller/DataModuleController.php
@@ -109,8 +109,8 @@ class DataModuleController extends ActionController
                 parent::initializeView($view);
             }
             $publicResourcesPath = PathUtility::getAbsoluteWebPath(
-                    ExtensionManagementUtility::extPath('external_import')
-                ) . 'Resources/Public/';
+                ExtensionManagementUtility::extPath('external_import') . 'Resources/Public/'
+            );
             $pageRenderer = $view->getModuleTemplate()->getPageRenderer();
             $pageRenderer->addCssFile($publicResourcesPath . 'StyleSheet/ExternalImport.css');
             $pageRenderer->addRequireJsConfiguration(

--- a/Classes/Controller/LogModuleController.php
+++ b/Classes/Controller/LogModuleController.php
@@ -20,6 +20,7 @@ namespace Cobweb\ExternalImport\Controller;
 use Cobweb\ExternalImport\Domain\Repository\LogRepository;
 use TYPO3\CMS\Backend\View\BackendTemplateView;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\PathUtility;
 use TYPO3\CMS\Core\Utility\VersionNumberUtility;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
@@ -78,8 +79,8 @@ class LogModuleController extends ActionController
         }
         $pageRenderer = $view->getModuleTemplate()->getPageRenderer();
         $publicResourcesPath = PathUtility::getAbsoluteWebPath(
-                ExtensionManagementUtility::extPath('external_import')
-            ) . 'Resources/Public/';
+            ExtensionManagementUtility::extPath('external_import') . 'Resources/Public/'
+        );
         $pageRenderer->addCssFile($publicResourcesPath . 'StyleSheet/ExternalImport.css');
         $pageRenderer->addRequireJsConfiguration(
             [


### PR DESCRIPTION
Due to upcoming changes in typo3/cms-composer-installers v4.0.0
(currently available as RC1), composer packages are not linked
anymore to public folder typo3conf/ext/extension_name/.

As a result, web assets need to be resolved accordingly, see
https://github.com/TYPO3/CmsComposerInstallers/releases/tag/v4.0.0-RC1

In this particular scenario the change is simple, but (now) with
a corresponding distinction between "extension path" and "public
extension resources path":
* `PathUtility::getAbsoluteWebPath('EXT:extension_name/')` resolves
  to corresponding (private) folder in Composer `vendor/` folder
* `PathUtility::getAbsoluteWebPath('EXT:extension_name/Resources/Public')`
  resolves to (virtual) public path `typo3conf/ext/`

Fixes: https://forge.typo3.org/issues/96374