### PR TITLE
[BUGFIX] Merge customPermOptions

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -17,20 +17,23 @@ if (!is_array($GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['scheduler']['tasks'][\T
 }
 
 // Add custom permission options for the backend module
-$GLOBALS['TYPO3_CONF_VARS']['BE']['customPermOptions'] = [
-    'tx_externalimport_bemodule_actions' => [
-        'header' => 'LLL:EXT:external_import/Resources/Private/Language/ExternalImport.xlf:bemodulePermissions',
-        'items' => [
-            'sync' => [
-                'LLL:EXT:external_import/Resources/Private/Language/ExternalImport.xlf:bemodulePermissions.runSync',
-                'actions-refresh',
-                'LLL:EXT:external_import/Resources/Private/Language/ExternalImport.xlf:bemodulePermissions.runSync.description'
-            ],
-            'scheduler' => [
-                'LLL:EXT:external_import/Resources/Private/Language/ExternalImport.xlf:bemodulePermissions.scheduler',
-                'mimetypes-x-tx_scheduler_task_group',
-                'LLL:EXT:external_import/Resources/Private/Language/ExternalImport.xlf:bemodulePermissions.scheduler.description'
+\TYPO3\CMS\Core\Utility\ArrayUtility::mergeRecursiveWithOverrule(
+    $GLOBALS['TYPO3_CONF_VARS']['BE']['customPermOptions'],
+    [
+        'tx_externalimport_bemodule_actions' => [
+            'header' => 'LLL:EXT:external_import/Resources/Private/Language/ExternalImport.xlf:bemodulePermissions',
+            'items' => [
+                'sync' => [
+                    'LLL:EXT:external_import/Resources/Private/Language/ExternalImport.xlf:bemodulePermissions.runSync',
+                    'actions-refresh',
+                    'LLL:EXT:external_import/Resources/Private/Language/ExternalImport.xlf:bemodulePermissions.runSync.description'
+                ],
+                'scheduler' => [
+                    'LLL:EXT:external_import/Resources/Private/Language/ExternalImport.xlf:bemodulePermissions.scheduler',
+                    'mimetypes-x-tx_scheduler_task_group',
+                    'LLL:EXT:external_import/Resources/Private/Language/ExternalImport.xlf:bemodulePermissions.scheduler.description'
+                ]
             ]
         ]
     ]
-];
+);


### PR DESCRIPTION
This extension overwrites customPermOptions which overwrites customPermOptions of other extension.
Instead, merging it with the previous value is the way to go. Per default, customPermOptions is an empty array.