### PR TITLE
Skip missing additionalFields on data store

### DIFF
--- a/Classes/Step/StoreDataStep.php
+++ b/Classes/Step/StoreDataStep.php
@@ -799,7 +799,7 @@ class StoreDataStep extends AbstractStep
                 $this->valuesExcludedFromSaving[$id] = [];
                 foreach ($columnConfiguration as $name => $configuration) {
                     // The values that are excluded are temporarily stored for later restoration
-                    if (array_key_exists(Configuration::DO_NOT_SAVE_KEY, $configuration)) {
+                    if (array_key_exists(Configuration::DO_NOT_SAVE_KEY, $configuration) && array_key_exists($name, $record)) {
                         $this->valuesExcludedFromSaving[$id][$name] = $record[$name];
                         // Make sure a value actually exists
                     } elseif (isset($record[$name])) {


### PR DESCRIPTION
This avoids an "undefined array key" error in case "additionalFields" contains a field which may be missing in a record.