### PR TITLE
[BUGFIX] Fix error message when there is an SQL error

### DIFF
--- a/Classes/Step/StoreDataStep.php
+++ b/Classes/Step/StoreDataStep.php
@@ -1036,13 +1036,18 @@ class StoreDataStep extends AbstractStep
                 while ($row = $result->fetchAssociative()) {
                     // Check if there's a label for the message
                     $labelCode = 'msg_' . $row['type'] . '_' . $row['action'] . '_' . $row['details_nr'];
-                    $label = LocalizationUtility::translate(
-                        'LLL:EXT:belog/mod/locallang.xml:' . $labelCode,
-                        'belog'
-                    );
                     // If not, use details field
-                    if (empty($label)) {
-                        $label = $row['details'];
+                    $dataArray = json_decode( $row['log_data'], true);
+                    if ($dataArray !== null) {
+                        $dataArray = json_decode( $row['log_data'], true);
+                        $label = LocalizationUtility::translate(
+                            'LLL:EXT:belog/Resources/Private/Language/locallang.xlf:' . $labelCode,
+                            'belog',
+                            [$dataArray['reason']??'unknown', ($dataArray['table']??'unknown table') . ': ' . $dataArray['uid']??'0']
+                        );
+                    }
+                    if ($label === null) {
+                        $label = $dataArray['reason'] ?? $dataArray['details'] ?? 'Unkown Reason';
                     }
                     // Substitute the first 5 items of extra data into the error message
                     $message = $label;


### PR DESCRIPTION
- The locallang files in belog have been moved since many versions: fixed the path and input additional needed arguments
- The default message must be taken from log_data,
- "details" contains the Default error message in english without replaced substitutes
- Add some fallbacks if information is not set

resolves #297