### PR TITLE
[BUGFIX] Test if reactions is loaded

### DIFF
--- a/Configuration/TCA/Overrides/sys_reaction.php
+++ b/Configuration/TCA/Overrides/sys_reaction.php
@@ -4,7 +4,7 @@ use Cobweb\ExternalImport\Reaction\ImportReaction;
 use Cobweb\ExternalImport\Utility\CompatibilityUtility;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 
-if (CompatibilityUtility::isV12()) {
+if (CompatibilityUtility::isV12() && ExtensionManagementUtility::isLoaded('reactions')) {
     ExtensionManagementUtility::addTcaSelectItem(
         'sys_reaction',
         'reaction_type',


### PR DESCRIPTION
If reactions is not loaded this will cause an error as addTcaSelectItems does not work then