### PR TITLE
Fix deprecation warnings of QueryBuilder::execute()

### DIFF
--- a/Classes/Domain/Repository/ChildrenRepository.php
+++ b/Classes/Domain/Repository/ChildrenRepository.php
@@ -39,7 +39,7 @@ class ChildrenRepository
     {
         $existingRecords = [];
         $queryBuilder = $this->prepareQueryBuilder($table, $conditions);
-        $result = $queryBuilder->execute();
+        $result = $queryBuilder->executeQuery();
         while ($record = $result->fetch()) {
             $existingRecords[] = $record['uid'];
         }
@@ -60,7 +60,7 @@ class ChildrenRepository
     public function findFirstExistingRecord(string $table, array $conditions): int
     {
         $queryBuilder = $this->prepareQueryBuilder($table, $conditions);
-        $result = $queryBuilder->execute();
+        $result = $queryBuilder->executeQuery();
         $record = $result->fetchAssociative();
         if ($record) {
             return (int)$record['uid'];

--- a/Classes/Domain/Repository/SchedulerRepository.php
+++ b/Classes/Domain/Repository/SchedulerRepository.php
@@ -150,7 +150,7 @@ class SchedulerRepository implements SingletonInterface
             $rows = $queryBuilder->select('uid', 'groupName')
                 ->from('tx_scheduler_task_group')
                 ->orderBy('groupName')
-                ->execute();
+                ->executeQuery();
             while ($row = $rows->fetchAssociative()) {
                 $groups[$row['uid']] = $row['groupName'];
             }

--- a/Classes/Domain/Repository/UidRepository.php
+++ b/Classes/Domain/Repository/UidRepository.php
@@ -95,7 +95,7 @@ class UidRepository
         if (count($constraints) > 0) {
             $queryBuilder->where(...$constraints);
         }
-        $result = $queryBuilder->execute();
+        $result = $queryBuilder->executeQuery();
         if ($result) {
             while ($row = $result->fetchAssociative()) {
                 // Don't consider records with empty references, as they can't be matched

--- a/Classes/Step/StoreDataStep.php
+++ b/Classes/Step/StoreDataStep.php
@@ -1039,7 +1039,7 @@ class StoreDataStep extends AbstractStep
                 ->setMaxResults(
                     count($errorLog)
                 )
-                ->execute();
+                ->executeQuery();
             if ($result) {
                 while ($row = $result->fetchAssociative()) {
                     // Check if there's a label for the message

--- a/Classes/Utility/MappingUtility.php
+++ b/Classes/Utility/MappingUtility.php
@@ -221,7 +221,7 @@ class MappingUtility implements ImporterAwareInterface
             $result = $queryBuilder->selectLiteral($referenceField, $valueField)
                 ->from($mappingData['table'])
                 ->where($whereClause)
-                ->execute();
+                ->executeQuery();
 
             // Fill hash table
             if ($result) {

--- a/Classes/Utility/SlugUtility.php
+++ b/Classes/Utility/SlugUtility.php
@@ -63,7 +63,7 @@ class SlugUtility
             ->from($table)
             ->where(
                 $queryBuilder->expr()->in('uid', $uids)
-            )->execute()
+            )->executeQuery()
             ->fetchAllAssociative();
         // Generate the new slug for each record
         $newSlugs = [];
@@ -78,7 +78,7 @@ class SlugUtility
                         ->set($field, $slug)
                         ->where(
                             $queryBuilder->expr()->eq('uid', $record['uid'])
-                        )->execute();
+                        )->executeStatement();
                 }
             }
         }


### PR DESCRIPTION
QueryBuilder::execute() is deprecated and will be removed in TYPO3 13. QueryBuilder::executeQuery/executeStatement() was added in 11.5. 
Without the changes the deprecation warnings lead to failure in functional tests.  