### PR TITLE
Prominently hint at import via URI (TYPO3 Reaction)

### DIFF
--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -31,7 +31,7 @@ External Import
 
 ----
 
-Tool for importing data from external sources into the TYPO3 database, using an extended TCA syntax. Provides a BE module, a Scheduler task, a command-line interface and an API.
+Tool for importing data from external sources into the TYPO3 database, using an extended TCA syntax. Provides a BE module, a Scheduler task, a command-line interface, imports via URI call (Reaction) and an API.
 
 ----
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
 	"name": "cobweb/external_import",
 	"type": "typo3-cms-extension",
-	"description": "Tool for importing data from external sources into the TYPO3 database, using an extended TCA syntax. Provides a BE module, a Scheduler task, a command-line tool and an API.",
+	"description": "Tool for importing data from external sources into the TYPO3 database, using an extended TCA syntax. Provides a BE module, a Scheduler task, a command-line tool, imports via URI call (Reaction) and an API.",
 	"license": [
 		"GPL-2.0-or-later"
 	],


### PR DESCRIPTION
The integration of TYPO3 Reactions to allow for triggering imports via URI calls completes the existing set of import options. This should be featured more prominently.