### PR TITLE
Properly output warnings from Reaction import

### DIFF
--- a/Classes/Reaction/ImportReaction.php
+++ b/Classes/Reaction/ImportReaction.php
@@ -99,7 +99,7 @@ class ImportReaction implements ReactionInterface
                 'messages' => $messages[AbstractMessage::OK],
             ];
             if (count($messages[AbstractMessage::WARNING]) > 0) {
-                $responseBody['warnings'] .= $messages[AbstractMessage::WARNING];
+                $responseBody['warnings'] = $messages[AbstractMessage::WARNING];
             }
             return $this->jsonResponse($responseBody);
         } catch (InvalidPayloadException $e) {


### PR DESCRIPTION
Avoid this error:

> PHP Warning: Undefined array key "warnings" in /.../vendor/cobweb/external_import/Classes/Reaction/ImportReaction.php line 102