### PR TITLE
Prevent Log module search/filter form submit

### DIFF
--- a/Resources/Private/Templates/LogModule/List.html
+++ b/Resources/Private/Templates/LogModule/List.html
@@ -9,14 +9,14 @@
 	<h1><f:translate id="logList" /></h1>
 
 	<div id="tx_externalimport_loglist_wrapper" class="hidden">
-		<form name="searchAndFilter">
-			<div class="form-group">
-				<f:form.textfield name="externalimport-searchfield" placeholder="{f:translate(key:'search')}"
-								  id="tx_externalimport_search"
-								  class="form-control t3js-externalimport-searchfield"/>
-			</div>
-
-		</form>
+		<div class="form-group">
+			<input
+					name="externalimport-searchfield"
+					placeholder="{f:translate(key:'search')}"
+					id="tx_externalimport_search"
+					class="form-control t3js-externalimport-searchfield"
+			>
+		</div>
 		<div class="table-fit">
 			<table class="table table-striped table-hover" id="tx_externalimport_loglist">
 				<thead>


### PR DESCRIPTION
The search/filter field is handled by javascript and triggers filtering while it is filled. Submitting the form causes the TYPO3 backend to be rendered inside the module. Avoid this by dropping the form which does not have a purpose anyways.

As additional change the field is rendered as plain HTML since there is no relation to a Fluid form and no requirement for a generated form field name.

Fixes #398