### PR TITLE
[BUGFIX] Task deserialize expects array instead of string

### DIFF
--- a/Classes/Domain/Repository/SchedulerRepository.php
+++ b/Classes/Domain/Repository/SchedulerRepository.php
@@ -174,7 +174,7 @@ class SchedulerRepository implements SingletonInterface
                 $this->tasks[] = $task;
             } else {
                 try {
-                    $task = $this->taskSerializer->deserialize($row['serialized_task_object']);
+                    $task = $this->taskSerializer->deserialize($row);
                     // Add the task to the list only if it is valid
                     if (get_class($task) === self::$taskClassName && (new TaskValidator())->isValid($task)) {
                         if (method_exists($task, 'setScheduler')) {


### PR DESCRIPTION
Seems as if the methode signature has change in at least TYPO3 v14. Related to #396 